### PR TITLE
Respect $PATH for picking the interpreter

### DIFF
--- a/gh-desktop-notifications.py
+++ b/gh-desktop-notifications.py
@@ -1,5 +1,4 @@
-#!/usr/local/bin/python
-# Use the brew python
+#!/usr/bin/env python
 
 import json
 from os import path


### PR DESCRIPTION
This ought to work on all Unix-like systems, rather than breaking on systems which only have `/usr/bin/python` (or some other location), like Debian.

If you have a prefered python interpreter, it ought to be first in `${PATH}` anyway.
